### PR TITLE
Set messages as nonexistent instead of using a blank message key

### DIFF
--- a/extension.json
+++ b/extension.json
@@ -9,9 +9,6 @@
 	"Hooks": {
 		"MessageCache::get": "MessageCachePerformance::onMessageCacheGet"
 	},
-	"MessagesDirs": {
-		"MessageCachePerformance": "i18n"
-	},
 	"manifest_version": 2,
 	"license-name": "Apache-2.0"
 }

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,3 +1,0 @@
-{
-	"fandom-msg-cache-performance-blank": ""
-}


### PR DESCRIPTION
The current logic that reroutes messages known to not exist to use a blank
system message under the hood is incompatible with some existing code paths
(e.g. LanguageConverter) that rely on a Message::exists() existence check to
trigger fallback logic. Instead, let's return false from the hook handler for
message keys that are known to not exist to avoid expensive MessageCache
operations while maintaining compatibility with code that relies on message
existence checks to function correctly. This is made possible by
https://github.com/Wikia/mediawiki/pull/19.