### PR TITLE
Use an Aho-Corasick matcher when searching for prefixes

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,10 @@
+{
+	"name": "mediawiki/message-cache-performance",
+	"type": "mediawiki-extension",
+	"description": "Avoid redundant MessageCache lookups",
+	"license": "Apache-2.0",
+	"require": {
+		"php": ">=5.4",
+		"wikimedia/aho-corasick": "v1.0.1"
+	}
+}


### PR DESCRIPTION
Optimize the message prefix search by short-circuiting the handling if the
message key is known to exist in code, and using an Aho-Corasick matcher for the
actual search over a naive loop.