### PR TITLE
Make matcherDataProvider static

### DIFF
--- a/tests/unit/HooksTest.php
+++ b/tests/unit/HooksTest.php
@@ -92,7 +92,7 @@ class HooksTest extends TestCase {
 		}
 	}
 
-	public function matcherDataProvider() {
+	public static function matcherDataProvider() {
 		return [
 			'single key' => [ [ 'matched_key' ], [ 'matched_key' => false ] ],
 			'multiple keys' => [


### PR DESCRIPTION
PHPUnit 10 will only support static data provider methods.